### PR TITLE
Fixed autoinject signature.

### DIFF
--- a/master/typings/aurelia/aurelia-dependency-injection.d.ts
+++ b/master/typings/aurelia/aurelia-dependency-injection.d.ts
@@ -322,8 +322,8 @@ declare module 'aurelia-dependency-injection/container' {
 declare module 'aurelia-dependency-injection/index' {
 	export { TransientRegistration, SingletonRegistration, Resolver, Lazy, All, Optional, Parent, ClassActivator, FactoryActivator } from 'aurelia-dependency-injection/metadata';
 	export { Container } from 'aurelia-dependency-injection/container';
-	export function autoinject(target: any): void | ((target: any) => void);
-	export function inject(...rest: any[]): (target: any) => void;
+	export function autoinject(): ClassDecorator
+	export function inject(...rest: any[]): ClassDecorator;
 	export function registration(value: any): (target: any) => void;
 	export function transient(key: any): (target: any) => void;
 	export function singleton(keyOrRegisterInChild: any, registerInChild?: boolean): (target: any) => void;


### PR DESCRIPTION
I tried to use autoinject in my typescript project, but it was giving type errors with the latest version of aurelia-dependency-injection.d.ts. This change should resolve the issue. I used the built-in ClassDecorator type for simplicity.

Tested with typescript 1.5 beta and aurelia/dependency-injection@0.7.1.