### PR TITLE
added flag experimentalDecorators as required by TS compiler see rece…

### DIFF
--- a/skel-nav-esri-gulp/gulpfile.js
+++ b/skel-nav-esri-gulp/gulpfile.js
@@ -17,6 +17,7 @@ gulp.task('build-ts', function () {
          noExternalResolve: true,
          target: "es5",
          module: "amd",
+         experimentalDecorators: true,
          emitDecoratorMetadata: true
     }));
 


### PR DESCRIPTION
added flag experimentalDecorators as required by TS compiler.
See recent change in TypeScript:
https://github.com/Microsoft/TypeScript/commit/62ba36908bceed22a52cee3269223189397cbab5#diff-e119cc28df9582f9e1ca0d41720ea142R2025
that adds the error message shown in compiler output:

error TS6064: Option 'experimentalDecorators' must also be specified when option 'emitDecoratorMetadata' is specified.
[18:57:25] TypeScript: 1 global error
[18:57:25] TypeScript: emit succeeded (with errors)